### PR TITLE
Fix SSL import error and socket_port configuration issue

### DIFF
--- a/z0.py
+++ b/z0.py
@@ -77,7 +77,7 @@ def main():
             task_push_from_name('loader', fake_req, fake_resp)
         start()
     elif conf.server_addr:
-        server = BackgroundServer(port=conf.socket_port).start()
+        server = BackgroundServer(port=conf.console_port).start()
         KB["continue"] = True
         # 启动漏洞扫描器
         scanner = threading.Thread(target=start)


### PR DESCRIPTION
- Replace deprecated ssl.wrap_socket with ssl.create_default_context() in baseproxy.py for Python 3.12+ compatibility
- Fix KeyError: 'socket_port' by using conf.console_port instead in z0.py